### PR TITLE
Update Main Backend to Use New AI Service with Assistants API Integration

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -22,7 +22,6 @@ func init() {
 
 func main() {
 	r := router.NewRouter() // Initialize your router
-	services.InitRedis()
 
 	// Set CORS options
 	headersOk := handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type", "Authorization"})

--- a/backend/pkg/context/app_context.go
+++ b/backend/pkg/context/app_context.go
@@ -1,0 +1,15 @@
+package context
+
+import "sync"
+
+// AppContext holds shared data like assistant IDs
+type AppContext struct {
+	AssistantIDs sync.Map // Map to store assistant IDs by videoID
+}
+
+// Global instance of AppContext
+var Instance *AppContext
+
+func init() {
+	Instance = &AppContext{}
+}

--- a/backend/pkg/handlers/aiHandler.go
+++ b/backend/pkg/handlers/aiHandler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"YOUTUBE-LEARNING-MODE/pkg/context"
 	"YOUTUBE-LEARNING-MODE/pkg/services"
 	"encoding/json"
 	"log"
@@ -32,8 +33,16 @@ func AskGPTQuestion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Retrieve the assistantID from context using videoID
+	assistantIDValue, ok := context.Instance.AssistantIDs.Load(questionReq.VideoID)
+	if !ok {
+		http.Error(w, "Assistant session not found for this video", http.StatusBadRequest)
+		return
+	}
+	assistantID, _ := assistantIDValue.(string)
+
 	// Ask GPT the question
-	aiResponse, err := services.AskGPTQuestion(questionReq.VideoID, questionReq.UserQuestion)
+	aiResponse, err := services.AskGPTQuestion(questionReq.VideoID, assistantID, questionReq.UserQuestion)
 	if err != nil {
 		log.Printf("Failed to get AI response: %v", err)
 		http.Error(w, "Failed to get AI response", http.StatusInternalServerError)

--- a/backend/pkg/handlers/videoContextHandler.go
+++ b/backend/pkg/handlers/videoContextHandler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"YOUTUBE-LEARNING-MODE/pkg/context"
 	"YOUTUBE-LEARNING-MODE/pkg/services"
 	"encoding/json"
 	"log"
@@ -45,13 +46,14 @@ func ProcessVideo(w http.ResponseWriter, r *http.Request) {
 		log.Println("Failed to store video info in Redis:", err)
 	}
 
-	// Initialize GPT session with video info
-	err = services.InitGPTSession(videoID, videoInfo.Title, videoInfo.Channel, videoInfo.Transcript)
+	// Initialize Assistant session with video info
+	assistantID, err := services.InitGPTSession(videoID, videoInfo.Title, videoInfo.Channel, videoInfo.Transcript)
 	if err != nil {
-		log.Println("Failed to initialize GPT session:", err)
-		http.Error(w, "Failed to initialize GPT session", http.StatusInternalServerError)
+		log.Println("Failed to initialize assistant session:", err)
+		http.Error(w, "Failed to initialize assistant session", http.StatusInternalServerError)
 		return
 	}
+	context.Instance.AssistantIDs.Store(videoID, assistantID)
 
 	// Extract timestamps from the transcript
 	timestamps := ExtractTimestampsFromTranscript(videoInfo.Transcript)

--- a/backend/pkg/services/aiService.go
+++ b/backend/pkg/services/aiService.go
@@ -22,28 +22,31 @@ type AIRequest struct {
 }
 
 // InitGPTSession initializes a GPT session for the given video information.
-func InitGPTSession(videoID, title, channel string, transcript []string) error {
+func InitGPTSession(videoID, title, channel string, transcript []string) (string, error) {
+	// Join the transcript array into a single string
+	transcriptStr := strings.Join(transcript, " ")
+
 	// Create the AIRequest payload
 	payload := map[string]interface{}{
 		"video_id":   videoID,
 		"title":      title,
 		"channel":    channel,
-		"transcript": transcript,
+		"transcript": transcriptStr,
 	}
 
 	// Convert payload to JSON
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		return fmt.Errorf("failed to marshal AIRequest: %v", err)
+		return "", fmt.Errorf("failed to marshal AIRequest: %v", err)
 	}
 	log.Println("this is the req body::", string(payloadBytes))
 
-	// Create an HTTP POST request
+	// Create an HTTP POST request to initialize the session
 	aiServiceURL := fmt.Sprintf("%s/ai/init-session", config.AiServiceURL)
 	client := &http.Client{Timeout: 10 * time.Second}
 	req, err := http.NewRequest("POST", aiServiceURL, bytes.NewBuffer(payloadBytes))
 	if err != nil {
-		return fmt.Errorf("failed to create request: %v", err)
+		return "", fmt.Errorf("failed to create request: %v", err)
 	}
 
 	// Set the content-type header to application/json
@@ -52,33 +55,47 @@ func InitGPTSession(videoID, title, channel string, transcript []string) error {
 	// Make the HTTP request
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to initialize GPT session: %v", err)
+		return "", fmt.Errorf("failed to initialize GPT session: %v", err)
 	}
 	defer resp.Body.Close()
 
 	// Read response body for debugging purposes
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("failed to read response body: %v", err)
+		return "", fmt.Errorf("failed to read response body: %v", err)
 	}
 
 	// Check if the response is successful
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("AI service returned an error: %v, Body: %s", resp.Status, string(body))
+		return "", fmt.Errorf("AI service returned an error: %v, Body: %s", resp.Status, string(body))
 	}
 
-	return nil
+	// Parse the JSON response to get the assistant ID
+	var responseData map[string]string
+	err = json.Unmarshal(body, &responseData)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse AI session response: %v", err)
+	}
+
+	assistantID, ok := responseData["assistant_id"]
+	if !ok {
+		return "", fmt.Errorf("assistant_id not found in response: %v", responseData)
+	}
+
+	// Return the assistant ID for future use
+	return assistantID, nil
 }
 
-// AskGPTQuestion sends a question to the AI service and returns the response.
-func AskGPTQuestion(videoID, userQuestion string) (string, error) {
+// AskGPTQuestion sends a question to the AI service using the assistant_id and returns the response.
+func AskGPTQuestion(videoID, assistantID, userQuestion string) (string, error) {
 	// Log the incoming parameters for debugging
-	log.Printf("Preparing to ask GPT a question. VideoID: %s, Question: %s", videoID, userQuestion)
+	log.Printf("Preparing to ask GPT a question. VideoID: %s, AssistantID: %s, Question: %s", videoID, assistantID, userQuestion)
 
-	// Create the AIRequest payload
-	reqPayload := AIRequest{
-		VideoID:      videoID,
-		UserQuestion: userQuestion,
+	// Create the request payload
+	reqPayload := map[string]interface{}{
+		"video_id":     videoID,
+		"assistant_id": assistantID,
+		"question":     userQuestion,
 	}
 
 	// Convert payload to JSON
@@ -90,9 +107,9 @@ func AskGPTQuestion(videoID, userQuestion string) (string, error) {
 	// Log the JSON payload for debugging
 	log.Printf("Request payload: %s", string(reqBody))
 
-	// Make HTTP POST request to the AI service
+	// Make HTTP POST request to the AI service to ask a question
 	aiServiceURL := fmt.Sprintf("%s/ai/ask-question", config.AiServiceURL)
-	client := &http.Client{Timeout: 20 * time.Second}
+	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Post(aiServiceURL, "application/json", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return "", fmt.Errorf("failed to send question to GPT: %v", err)
@@ -108,26 +125,24 @@ func AskGPTQuestion(videoID, userQuestion string) (string, error) {
 	// Log the raw response for debugging
 	log.Printf("Raw AI Response: %s", string(body))
 
-	// Check if the content type contains "application/json"
-	contentType := resp.Header.Get("Content-Type")
-	log.Printf("Response Content-Type: %s", contentType) // Log the content type for debugging
-	if !strings.Contains(contentType, "application/json") {
-		return "", fmt.Errorf("AI service returned a non-JSON response: %s", string(body))
-	}
-
-	// Parse the JSON response
+	// Parse the JSON response to get the assistant's answer
 	var aiResponse map[string]string
 	err = json.Unmarshal(body, &aiResponse)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse AI response: %v", err)
 	}
 
-	// Check if "response" field is present
-	gptResponse, ok := aiResponse["response"]
+	// Check if the response contains the 'answer' field
+	answer, ok := aiResponse["answer"]
 	if !ok {
-		return "", fmt.Errorf("AI response did not contain 'response' field: %v", aiResponse)
+		return "", fmt.Errorf("AI response did not contain 'answer' field: %v", aiResponse)
 	}
 
-	// Return the GPT response
-	return gptResponse, nil
+	// Return the assistant's answer
+	return answer, nil
+}
+
+// AIServiceURL is the configuration for the base URL of the AI service
+func getAIServiceURL() string {
+	return config.AiServiceURL
 }


### PR DESCRIPTION
This PR updates the main backend to make requests compatible with the refactored AI service, which now utilizes the OpenAI Assistants API. The backend no longer needs to repeatedly send the entire transcript and history with each question. Instead, it initializes a session once and then passes user questions along with the video_id to maintain the context within the assistant session.

This change is for the time being until we handle user sessions with unique IDs.


Please Review [AI-Service PR](https://github.com/AnasKhan0607/Youtube-Learning-Mode-Ai-Service/pull/1) first

### Key Changes:
**ProcessVideo Handler:** Adjusted to initialize the assistant session by sending the video metadata (title, channel, and transcript) to the AI service’s new /ai/init-session endpoint. The handler now stores the returned assistant_id in the shared context.Instance, keyed by video_id.

**AskGPTQuestion Handler:** Modified to retrieve the stored assistant_id from the context.Instance based on the video_id for each user question. It then sends the question to the AI service’s /ai/ask-question endpoint, keeping the context within the assistant session established in the ProcessVideo handler.

This update aligns the main backend with the newly optimized AI service and ensures efficient context management using the Assistants API.